### PR TITLE
Enable manually setup option type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ setup(
 
     packages=['virtTrinity'],
 
+    data_files=[
+        ('virtTrinity/data', ['virtTrinity/data/virsh_option_types.json'])
+    ],
+
     cmdclass={
         'test': SelfTest,
     },

--- a/virtTrinity/command.py
+++ b/virtTrinity/command.py
@@ -15,6 +15,7 @@ class Command(object):
             self.load_from_help(name)
 
     def load_from_help(self, name):
+        self.short_name = name
         help_txt = subprocess.check_output(
             ['virsh', 'help', name]).splitlines()
 
@@ -42,13 +43,12 @@ class Command(object):
         assert name == self.name.split()[0]
         assert self.synopsis
         self.parse_options()
-        self.short_name = name
 
     def parse_options(self):
         options = []
         if self.options:
             for opt_line in self.options:
-                options.append(option.Option(opt_line))
+                options.append(option.Option(opt_line, command=self))
         if '...' in self.synopsis:
             options[-1].argv = True
         self.options = options

--- a/virtTrinity/data/virsh_option_types.json
+++ b/virtTrinity/data/virsh_option_types.json
@@ -1,0 +1,5 @@
+{
+    "attach-device": {
+        "file": "device_xml"
+    }
+}

--- a/virtTrinity/option_type.py
+++ b/virtTrinity/option_type.py
@@ -28,6 +28,10 @@ class OptionType(object):
             'file',
             'not_set',
         ],
+        'device_xml': [
+            'device_xml',
+            'not_set',
+        ],
     }
 
     def __init__(self, type_name):
@@ -54,6 +58,9 @@ class OptionType(object):
 
     def parse_file(self):
         return 'virt-trinity-file'
+
+    def parse_device_xml(self):
+        return 'virt-trinity-device.xml'
 
     def parse_type(self, type_name):
         parse_fun = getattr(self, 'parse_' + type_name)


### PR DESCRIPTION
This is done by adding option types in the JSON file:
virtTrinity/data/virsh_option_types.json.

Signed-off-by: Hao Liu hliu@redhat.com
